### PR TITLE
Implement the docking of calculator and parser

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, PartialEq)]
 pub enum Line {
     Expression(Expr),
     Sentence(ID, Expr)
@@ -8,7 +9,6 @@ pub enum Line {
  * the latter is an operator
  */
 #[derive(Debug, PartialEq)]
-
 pub enum Expr {
     Id(ID),
     Int(i64),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,8 +11,7 @@ pub enum Line {
 #[derive(Debug, PartialEq)]
 pub enum Expr {
     Id(ID),
-    Int(i64),
-    Float(f64),
+    Value(f64),
     Operation {
         l: Box<Expr>,
         r: Box<Expr>,
@@ -29,7 +28,6 @@ pub enum Operator {
     Power,
     Root,
     Log,
-    Assign,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/calculator.rs
+++ b/src/calculator.rs
@@ -1,11 +1,17 @@
 use std::collections::HashMap;
 
+use lalrpop_util::lalrpop_mod;
+use lalrpop_util::ParseError;
+use lalrpop_util::lexer::Token;
+
 use crate::utils::file;
 use crate::ast::{ID, Expr, Line};
 
 struct Calculator {
     symbol_table: HashMap<ID, f64>
 }
+
+// type ParseError = lalrpop_util::ParseError<usize, Token<'_>, &str>;
 
 impl Calculator {
 
@@ -24,7 +30,7 @@ impl Calculator {
     /* --------------- calculator --------------- */
 
     // return error type to be determined
-    pub fn calculate_expr(&mut self, line: &str) -> Result<f64, ()> {
+    pub fn calculate_expr(&mut self, line: &str) -> Result<f64, ParseError<usize, Token<'_>, &str>> {
         self.before_calculate();
         
         let parser_result = parse_line(line)?;
@@ -33,11 +39,11 @@ impl Calculator {
             self.handle_expression(&expr)
         } else {
             // an error will occur when parsing sentence
-            Err(())
+            todo!()
         }
     }
 
-    pub fn calculate_file(&mut self, file_path: &str) -> Result<Vec<f64>, ()> {
+    pub fn calculate_file(&mut self, file_path: &str) -> Result<Vec<f64>, ParseError<usize, Token<'_>, &str>> {
         // init the status
         self.before_calculate();
 
@@ -46,7 +52,7 @@ impl Calculator {
             Err(_) => {
                 // TODO: you may need to define custom error
                 // rather than io error
-                return Err(())
+                return ParseError<(), (), &str>::User { error: () };
             }
         };
 
@@ -72,20 +78,26 @@ impl Calculator {
     /* --------------- handler --------------- */
 
     // TODO: expression will return value
-    fn handle_expression(&mut self, expr: &Expr) -> Result<f64, ()> {
+    fn handle_expression(&mut self, expr: &Expr) -> Result<f64, ParseError<usize, Token<'_>, &str>> {
         todo!()
     }
 
     // TODO: sentence won't return value
-    fn handle_sentence(&mut self, id: &ID, expr: &Expr) -> Result<(), ()> {
+    fn handle_sentence(&mut self, id: &ID, expr: &Expr) -> Result<(), ParseError<usize, Token<'_>, &str>> {
         todo!()
     }
 }
 
 /* --------------- parser --------------- */
 
+lalrpop_mod!(pub parser);
+
 // encapsulate the lalrpop interface
-fn parse_line(line: &str) -> Result<Line, ()> {
+fn parse_line(line: &str) -> Result<Line, ParseError<usize, Token<'_>, &str>> {
+    let result = parser::LineParser::new().parse(line)?;
+
+    dbg!(result);
+    
 
     todo!()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,17 @@ mod test {
     mod level1;
     mod expr;
     mod factor;
+
+    mod calculator {
+        mod unit;
+    }
 }
 
 mod calculator;
 
 mod utils {
     pub mod file;
+    pub mod error;
 }
 
 fn main() {

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -179,3 +179,10 @@ pub Expr: Box<ast::Expr> = {
 //         r, 
 //         opt: ast::Operator::Assign
 //     }),
+
+pub Line: ast::Line = {
+    // the type of Expr parsing result is Box
+    // so you should use * to deref it 
+    <id: Id> ASSIGN <expr: Expr> => ast::Line::Sentence(id, *expr),
+    <Expr> => ast::Line::Expression(*<>),
+} 

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -13,13 +13,13 @@ grammar;
 match {
     r"[0-9]"
 } else {
-    r"-?[1-9][0-9]+|0",
+    r"-?(0|[1-9]\d*)(\.\d+)?",
     _
 }
 
 ASSIGN = "=";
 Subscript = "_";
-Supscript = "^";
+Superscript = "^";
 
 LP = "(";
 RP = ")";
@@ -41,15 +41,12 @@ SubOpt: ast::Operator =     { "-" => ast::Operator::Sub}
 MulOpt: ast::Operator =     { r"\*|\times" => ast::Operator::Mul}
 DivOpt: ast::Operator =     { r"/|\div" => ast::Operator::Div}
 
-pub (crate) Int: i64 = {
-    r"-?[1-9][0-9]+|0" => i64::from_str(<>).unwrap()
+SingleNumber: f64 = {
+    r"[0-9]" => f64::from_str(<>).unwrap()
 }
 
-SingleInt: i64 = {
-    r"[0-9]" => i64::from_str(<>).unwrap()
-}
-
-pub (crate) Float: f64 = {
+// [deprecated] merge int and float into value
+pub (crate) Value: f64 = {
     // simple float type implement
     r"-?(0|[1-9]\d*)(\.\d+)?" => f64::from_str(<>).unwrap()
 }
@@ -69,9 +66,8 @@ pub (crate) Id: ast::ID = {
 
 // 0. Parentheses (we merge value(int/float), id and parentheses)
 Term: Box<ast::Expr> = {
-    Float => Box::new(ast::Expr::Float(<>)),
-    Int => Box::new(ast::Expr::Int(<>)),
-    Id => Box::new(ast::Expr::Id(<>)),
+    Value => Box::new(ast::Expr::Value(<>)),
+    LatexTerm => <>,
 
     // you can see that the parser is a loop:
     // "Expr -> Factor -> level1 -> Term -> Expr"
@@ -80,7 +76,7 @@ Term: Box<ast::Expr> = {
 
 // this term is designed for latex syntax
 LatexTerm: Box<ast::Expr> = {
-    SingleInt => Box::new(ast::Expr::Int(<>)),
+    SingleNumber => Box::new(ast::Expr::Value(<>)),
     Id => Box::new(ast::Expr::Id(<>)),
 
     LC <expr: Expr> RC => expr
@@ -92,7 +88,7 @@ LatexTerm: Box<ast::Expr> = {
 // NOTICE Now Only Support Float Type Like this: a ^ {3.2} or \exp {3.2} (It can be optimization soon)
 // NOTICE Nesting of belows are not supported now
 Level1: Box<ast::Expr> = {
-    <l: LatexTerm> Supscript <r: LatexTerm> 
+    <l: LatexTerm> Superscript <r: LatexTerm> 
         => Box::new(ast::Expr::Operation{l, r, opt: ast::Operator::Power}),
 
     // e.g. \exp{(2)}
@@ -105,10 +101,11 @@ Level1: Box<ast::Expr> = {
             opt: ast::Operator::Power
         }),
 
+    // FIXME:
     //  \sqrt{}
     SQRT <r: LatexTerm> 
         => Box::new(ast::Expr::Operation{
-            l: Box::new(ast::Expr::Float(0.5)), 
+            l: Box::new(ast::Expr::Value(0.5)), 
             r, 
             opt: ast::Operator::Root
         }),
@@ -124,7 +121,7 @@ Level1: Box<ast::Expr> = {
     // \log{}
     LOG <r: LatexTerm> 
         => Box::new(ast::Expr::Operation{
-            l: Box::new(ast::Expr::Int(10)), 
+            l: Box::new(ast::Expr::Value(10.)), 
             r, 
             opt: ast::Operator::Log
         }),
@@ -169,16 +166,6 @@ pub Expr: Box<ast::Expr> = {
     <l: Expr> <opt: SubOpt> <r: Factor> => Box::new(ast::Expr::Operation{<>}),
     Factor => <>,
 }
-
-
-// assign formula is statement rather than expression (like rust)
-// // a = b
-// <l: LatexTerm> ASSIGN <r: LatexTerm> 
-//     => Box::new(ast::Expr::Operation{
-//         l, 
-//         r, 
-//         opt: ast::Operator::Assign
-//     }),
 
 pub Line: ast::Line = {
     // the type of Expr parsing result is Box

--- a/src/test/calculator/unit.rs
+++ b/src/test/calculator/unit.rs
@@ -1,0 +1,10 @@
+use crate::test::utils::{line_test_runner, new_value, new_operation};
+use crate::ast::{ID, Line, Operator};
+
+#[test]
+fn test_parse_line() {
+    line_test_runner(vec![
+        ("1 + 1", Line::Expression(new_operation(new_value(1.), new_value(1.), Operator::Plus))),
+        ("a = 1", Line::Sentence(ID::ASCII('a'), new_value(1.)))
+    ]);
+}

--- a/src/test/level1.rs
+++ b/src/test/level1.rs
@@ -17,8 +17,8 @@ fn power_test() {
             (
                 r"2 ^ {3.2}",
                 Expr::Operation {
-                    l: Box::new(Expr::Int(2)),
-                    r: Box::new(Expr::Float(3.2)),
+                    l: Box::new(Expr::Value(2.)),
+                    r: Box::new(Expr::Value(3.2)),
                     opt: Operator::Power,
                 },
             ),
@@ -26,7 +26,7 @@ fn power_test() {
                 r"\exp 2",
                 Expr::Operation {
                     l: Box::new(Expr::Id(ID::E)),
-                    r: Box::new(Expr::Int(2)),
+                    r: Box::new(Expr::Value(2.)),
                     opt: Operator::Power,
                 },
             ),
@@ -34,7 +34,7 @@ fn power_test() {
                 r"\exp {2.3}",
                 Expr::Operation {
                     l: Box::new(Expr::Id(ID::E)),
-                    r: Box::new(Expr::Float(2.3)),
+                    r: Box::new(Expr::Value(2.3)),
                     opt: Operator::Power,
                 },
             ),
@@ -65,23 +65,23 @@ fn sqrt_test() {
             (
                 r"\sqrt 2",
                 Expr::Operation {
-                    l: Box::new(Expr::Float(0.5)),
-                    r: Box::new(Expr::Int(2)),
+                    l: Box::new(Expr::Value(0.5)),
+                    r: Box::new(Expr::Value(2.)),
                     opt: Operator::Root,
                 },
             ),
             (
                 r"\sqrt {2.5}",
                 Expr::Operation {
-                    l: Box::new(Expr::Float(0.5)),
-                    r: Box::new(Expr::Float(2.5)),
+                    l: Box::new(Expr::Value(0.5)),
+                    r: Box::new(Expr::Value(2.5)),
                     opt: Operator::Root,
                 },
             ),
             (
                 r"\sqrt {(a)}",
                 Expr::Operation {
-                    l: Box::new(Expr::Float(0.5)),
+                    l: Box::new(Expr::Value(0.5)),
                     r: Box::new(Expr::Id(ID::ASCII('a'))),
                     opt: Operator::Root,
                 },
@@ -97,8 +97,8 @@ fn sqrt_test() {
             (
                 r"\sqrt[3]8",
                 Expr::Operation {
-                    l: Box::new(Expr::Int(3)),
-                    r: Box::new(Expr::Int(8)),
+                    l: Box::new(Expr::Value(3.)),
+                    r: Box::new(Expr::Value(8.)),
                     opt: Operator::Root,
                 },
             ),
@@ -121,23 +121,23 @@ fn log_test() {
             (
                 r"\log 2",
                 Expr::Operation {
-                    l: Box::new(Expr::Int(10)),
-                    r: Box::new(Expr::Int(2)),
+                    l: Box::new(Expr::Value(10.)),
+                    r: Box::new(Expr::Value(2.)),
                     opt: Operator::Log,
                 },
             ),
             (
                 r"\log {2.5}",
                 Expr::Operation {
-                    l: Box::new(Expr::Int(10)),
-                    r: Box::new(Expr::Float(2.5)),
+                    l: Box::new(Expr::Value(10.)),
+                    r: Box::new(Expr::Value(2.5)),
                     opt: Operator::Log,
                 },
             ),
             (
                 r"\log {(a)}",
                 Expr::Operation {
-                    l: Box::new(Expr::Int(10)),
+                    l: Box::new(Expr::Value(10.)),
                     r: Box::new(Expr::Id(ID::ASCII('a'))),
                     opt: Operator::Log,
                 },
@@ -146,7 +146,7 @@ fn log_test() {
                 r"\ln 2",
                 Expr::Operation {
                     l: Box::new(Expr::Id(ID::E)),
-                    r: Box::new(Expr::Int(2)),
+                    r: Box::new(Expr::Value(2.)),
                     opt: Operator::Log,
                 },
             ),
@@ -154,7 +154,7 @@ fn log_test() {
                 r"\ln {2.5}",
                 Expr::Operation {
                     l: Box::new(Expr::Id(ID::E)),
-                    r: Box::new(Expr::Float(2.5)),
+                    r: Box::new(Expr::Value(2.5)),
                     opt: Operator::Log,
                 },
             ),

--- a/src/test/lexer.rs
+++ b/src/test/lexer.rs
@@ -7,8 +7,8 @@ lalrpop_mod!(pub parser);
 #[test]
 fn id_test() {
     // Int test
-    assert_eq!(parser::IntParser::new().parse("22"), Ok(22));
-    assert_eq!(parser::FloatParser::new().parse("22.22"), Ok(22.22));
+    assert_eq!(parser::ValueParser::new().parse("22"), Ok(22.));
+    assert_eq!(parser::ValueParser::new().parse("22.22"), Ok(22.22));
 
     // ID test
     let id_map = vec![

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Expr, Greek, Operator, ID};
+use crate::ast::{Expr, Greek, Operator, ID, Line};
 use lalrpop_util::lalrpop_mod;
 
 lalrpop_mod!(pub parser);
@@ -6,6 +6,11 @@ lalrpop_mod!(pub parser);
 pub fn expr_test_runner(map: Vec<(&str, Expr)>) {
     map.into_iter()
         .for_each(|(k, v)| assert_eq!(parser::ExprParser::new().parse(k), Ok(Box::new(v))));
+}
+
+pub fn line_test_runner(map: Vec<(&str, Line)>) {
+    map.into_iter()
+        .for_each(|(k, v)| assert_eq!(parser::LineParser::new().parse(k), Ok(v)));
 }
 
 pub fn new_operation(l: Expr, r: Expr, opt: Operator) -> Expr {

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -8,13 +8,16 @@ pub fn expr_test_runner(map: Vec<(&str, Expr)>) {
         .for_each(|(k, v)| assert_eq!(parser::ExprParser::new().parse(k), Ok(Box::new(v))));
 }
 
-
 pub fn new_operation(l: Expr, r: Expr, opt: Operator) -> Expr {
     Expr::Operation { 
         l: Box::new(l), 
         r: Box::new(r), 
         opt 
     }
+}
+
+pub fn new_value(c: f64) -> Expr {
+    Expr::Value(c)
 }
 
 pub fn new_greek(c: Greek) -> Expr {

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -1,0 +1,12 @@
+use std::io::Error as IO_Error;
+use lalrpop_util::ParseError;
+use lalrpop_util::lexer::Token;
+
+
+pub enum CalculatorError<'input>{
+    IOError(IO_Error),
+    /// I don't know what will happen here when use 'static lifetime
+    ParseError(ParseError<usize, Token<'input>, &'static str>),
+
+    // you can define other types of error
+}


### PR DESCRIPTION
Initially, my focus was on docking of calculator and parser. However, I encouterd challenges while handling errors. To address this,  I introduced custom error type 'CaculatorError'. And then, the lifetime error caused by PaserError in LALRPOP bothered me. I had to add lifetime specifier for each function which uses references.

After everything is ok, when attempting to write some test cases for it, the parser struggled to handle even basic expressions like "1+1". At first, I integrated `Latex` into `LatexTerm` to solve it. And then, I found that it's unnecessary to distinct `Int` and `Float`, leading me to merge them.

This summarizes my efforts tonight. I've refactored a amount of code, so please be careful when merging it in the next PR. Thank you.