### PR TITLE
Introduce DualValue to handle some operation about `\log_28` or `\frac28` 

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -19,6 +19,16 @@ pub enum Expr {
     },
 }
 
+impl Expr {
+    pub fn new_value(value: f64) -> Box<Expr>{
+        Box::new(Expr::Value(value))
+    } 
+
+    pub fn new_operation(l: Box<Expr>, r: Box<Expr>, opt: Operator) -> Box<Expr> {
+        Box::new(Expr::Operation { l, r, opt})
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Operator {
     Plus,

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -1,5 +1,5 @@
 use crate::ast;
-use std::str::FromStr;
+use std::str::{FromStr, Chars};
 use lalrpop_util::ErrorRecovery;
 
 // grammar<'err>(errors: &'err mut Vec<ErrorlRecovery<usize, Token<'input>, &'static str>>);
@@ -10,11 +10,13 @@ grammar;
 // use match-use to set the priority of regular expression
 // remember use of _ at the end of else
 // otherwise the following expression won't be matched
+
 match {
+    r"\d\d" => DUAL_VALUE,
     r"[0-9]"
 } else {
-    r"-?(0|[1-9]\d*)(\.\d+)?",
-    _
+    r"-?(0|[1-9]\d*)(\.\d+)?" => VALUE,
+    _ 
 }
 
 ASSIGN = "=";
@@ -48,7 +50,9 @@ SingleNumber: f64 = {
 // [deprecated] merge int and float into value
 pub (crate) Value: f64 = {
     // simple float type implement
-    r"-?(0|[1-9]\d*)(\.\d+)?" => f64::from_str(<>).unwrap()
+    // r"[1-9][1-9][0-9]*" => f64::from_str(<>).unwrap(),
+    <VALUE> => f64::from_str(<>).unwrap(),
+    <DUAL_VALUE> => f64::from_str(<>).unwrap(),
 }
 
 pub (crate) Id: ast::ID = {
@@ -80,6 +84,27 @@ LatexTerm: Box<ast::Expr> = {
     Id => Box::new(ast::Expr::Id(<>)),
 
     LC <expr: Expr> RC => expr
+}
+
+LatexDualValue: (Box<ast::Expr>, Box<ast::Expr>) = {
+    <value: DUAL_VALUE> => {
+        let next_digit = |chars: &mut Chars| 
+            chars.next().unwrap().to_digit(10).unwrap() as f64;
+
+        let mut chars = value.chars();
+        let base = next_digit(&mut chars);
+        let argument = next_digit(&mut chars);
+        ( ast::Expr::new_value(base), ast::Expr::new_value(argument) )
+    }
+}
+
+LogPrefix: Box<ast::Expr> = {
+    // log = log_10 
+    LOG => Box::new(ast::Expr::Value(10.)),
+    // ln = log_e
+    LN =>Box::new(ast::Expr::Id(ast::ID::E)),
+    // log_n
+    LOG Subscript <l: LatexTerm> => <>,
 }
 
 // TODO deal with the mixed of calculate belows
@@ -119,26 +144,17 @@ Level1: Box<ast::Expr> = {
         }),
 
     // \log{}
-    LOG <r: LatexTerm> 
+    <l: LogPrefix> <r: LatexTerm> 
         => Box::new(ast::Expr::Operation{
-            l: Box::new(ast::Expr::Value(10.)), 
-            r, 
-            opt: ast::Operator::Log
+            l, r, opt: ast::Operator::Log
         }),
 
-    // \ln{}
-    LN <r: LatexTerm> 
-        => Box::new(ast::Expr::Operation{
-            l: Box::new(ast::Expr::Id(ast::ID::E)), 
-            r, 
-            opt: ast::Operator::Log
-        }),
-
-    //  \log_n{}
-    LOG Subscript <l: LatexTerm>  <r: LatexTerm> 
-        => Box::new(ast::Expr::Operation{
-            l, 
-            r, 
+    // \log_nm
+    // handle specific form such log_28->log_2{8}
+    LOG Subscript <dual_value: LatexDualValue> => 
+        Box::new(ast::Expr::Operation{
+            l: dual_value.0,
+            r: dual_value.1,
             opt: ast::Operator::Log
         }),
 
@@ -156,6 +172,13 @@ Factor: Box<ast::Expr> = {
     FRAC <l: LatexTerm> <r: LatexTerm>
         => Box::new(ast::Expr::Operation{
             l, r, opt: ast::Operator::Div
+        }),
+
+    FRAC <dual_value: LatexDualValue> => 
+        Box::new(ast::Expr::Operation{
+            l: dual_value.0,
+            r: dual_value.1,
+            opt: ast::Operator::Div
         }),
     Level1 => <>,
 }

--- a/src/test/calculator/unit.rs
+++ b/src/test/calculator/unit.rs
@@ -33,6 +33,24 @@ fn test_handle_sentence() {
 }
 
 #[test]
+fn test_calculate_expression() {
+    let cases = vec![
+        // FIXME: "1-2" can be parsed
+        ("1+2", 3.), ("1 - 2", -1.), ("1*2", 2.), ("1/2", 0.5), 
+        ("2^2", 4.), ("e^1", f64::consts::E), ("e^{-1}", f64::consts::E.recip()),
+        ("\\sqrt[3]8", 2.), ("\\log_2 8", 3.), ("\\ln e", 1.)
+    ];
+
+    let mut calculator = Calculator::new();
+    cases.iter().for_each(|(line, value)| {
+        match calculator.calculate_expr(line) {
+            Ok(r) => assert_eq!(r, *value),
+            Err(e) => {eprintln!("{}:\n{:#?}", line, e); assert!(false)}
+        };
+    })
+}
+
+#[test]
 fn test_handle_expression() {
     let mut test_cal = Calculator::new();
     // insert a and b into symbol table
@@ -80,7 +98,7 @@ fn test_handle_expression() {
             f64::consts::E.recip(),
         ),
         (
-            new_operation(new_value(8.0), new_value(3.0), Operator::Root),
+            new_operation(new_value(3.0), new_value(8.0), Operator::Root),
             2.0,
         ),
         (

--- a/src/test/expr.rs
+++ b/src/test/expr.rs
@@ -1,11 +1,14 @@
 use crate::ast::{Greek, Operator};
-use crate::test::utils::{expr_test_runner, new_operation, new_ascii, new_greek};
+use crate::test::utils::{expr_test_runner, new_operation, new_arithmetic, new_ascii, new_greek};
 
 // test expr parser
 #[test]
 fn expr_test() {
 
-    let cases = vec![(
+    let cases = vec![
+    ("12+23", new_arithmetic(12., 23., Operator::Plus)),
+    ("12-23", new_arithmetic(12., 23., Operator::Sub)),
+    (
         "a + b",
         new_operation(
             new_ascii('a'),

--- a/src/test/factor.rs
+++ b/src/test/factor.rs
@@ -1,5 +1,5 @@
 use crate::ast::{Expr, Greek, Operator, ID};
-use crate::test::utils::expr_test_runner;
+use crate::test::utils::{expr_test_runner, new_arithmetic};
 
 
 // test factor parser
@@ -23,6 +23,7 @@ fn factor_test() {
                     opt: Operator::Div,
                 },
             ),
+            ("\\frac12", new_arithmetic(1., 2., Operator::Div))
         ]
     )
 }

--- a/src/test/level1.rs
+++ b/src/test/level1.rs
@@ -1,6 +1,8 @@
 use crate::ast::{Expr, Operator, ID};
 use crate::test::utils::expr_test_runner;
 
+use super::utils::new_arithmetic;
+
 // test power
 #[test]
 fn power_test() {
@@ -174,6 +176,7 @@ fn log_test() {
                     opt: Operator::Log,
                 },
             ),
+            ( "\\log_28", new_arithmetic(2., 8., Operator::Log))
         ]
     )
 }

--- a/src/test/utils.rs
+++ b/src/test/utils.rs
@@ -21,6 +21,14 @@ pub fn new_operation(l: Expr, r: Expr, opt: Operator) -> Expr {
     }
 }
 
+pub fn new_arithmetic(l: f64, r: f64, opt: Operator) -> Expr {
+    Expr::Operation { 
+        l: Expr::new_value(l),
+        r: Expr::new_value(r),
+        opt
+    }
+}
+
 pub fn new_value(c: f64) -> Expr {
     Expr::Value(c)
 }


### PR DESCRIPTION
# What I did

1. The parser can't parse `\log_28` and `\frac28`. I use `DualValue` to implement it. I also used `LogPrefix` to unify different forms of Log.
2. And then, I write some simple cases to test that anything is ok.

Notice, although the operation `\log_210` can be displayed normally in Latex, it's illegal in our program.  

# Todo

The parser still can't parse `1-2`. The parser will thinks of it as `1` and `-2`.